### PR TITLE
chore: fix nix dev shell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -13,7 +13,9 @@ in
 
     buildInputs = [
       pkgs.rustToolchain
+      pkgs.llvmPackages_18.clang
     ];
 
     LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+    LIBCLANG_PATH = "${pkgs.llvmPackages_18.libclang.lib}/lib";
   }


### PR DESCRIPTION
Update `shell.nix` to work with C and C++ as RocksDB requires it.