### PR TITLE
build: reduce compile times by linking to pre-installed rocksdb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - "main"
 
+env:
+  ROCKSDB_LIB_DIR: /usr/lib/x86_64-linux-gnu/
+
 jobs:
   checks:
     name: Checks for linting and formatting
@@ -19,6 +22,10 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy, rustfmt
+
+      - name: Install dependencies
+        run: |
+          sudo apt install librocksdb-dev
 
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -14,6 +14,7 @@ in
     buildInputs = [
       pkgs.llvmPackages_18.clang
       pkgs.openssl
+      pkgs.rocksdb
       pkgs.rustToolchain
     ];
 
@@ -21,8 +22,10 @@ in
     LIBCLANG_PATH = "${pkgs.llvmPackages_18.libclang.lib}/lib";
 
     OPENSSL_DIR = "${pkgs.openssl.dev}";
-    OPENSSL_NO_VENDOR=1;
-    OPENSSL_LIB_DIR="${pkgs.lib.getLib pkgs.openssl}/lib";
+    OPENSSL_LIB_DIR = "${pkgs.lib.getLib pkgs.openssl}/lib";
+    OPENSSL_NO_VENDOR = 1;
 
     PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+
+    ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
   }


### PR DESCRIPTION
Compile times are now more like 2 minutes rather than 8 minutes as we aren't rebuilding RocksDB every single time